### PR TITLE
fix: TypeScript v6.0 の非推奨オプションを削除し tsconfig を根本修正

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,11 +23,10 @@
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
     "experimentalDecorators": true,
-    "ignoreDeprecations": "6.0",
-    "baseUrl": ".",
     "newLine": "LF",
+    "types": ["node"],
     "paths": {
-      "@/*": ["src/*"]
+      "@/*": ["./src/*"]
     }
   },
   "include": ["src/**/*"]


### PR DESCRIPTION
## 概要

TypeScript v6.0 アップグレード時の暫定対応として追加した `ignoreDeprecations: "6.0"` を削除し、根本的な修正を行います。

Fixes #2351

## 変更内容

### `tsconfig.json` の修正

- **`ignoreDeprecations: "6.0"` を削除**: TypeScript 7.0 では無効化されるため削除しました
- **`baseUrl: "."` を削除**: `moduleResolution: "bundler"` 環境では不要のため削除しました
- **`paths` を相対パスに更新**: `baseUrl` 削除に伴い、`"@/*": ["src/*"]` を `"@/*": ["./src/*"]` に変更しました
- **`types: ["node"]` を追加**: TypeScript 6.0 で `@types/node` の自動ロードが廃止されたため、明示的に追加しました

## 確認事項

- [x] `tsc --noEmit` による型チェックが通ることを確認
- [x] `pnpm lint` による Lint チェックが通ることを確認
