### PR TITLE
fix: eslint-plugin-unicorn v65 の新規ルール違反を修正

### DIFF
--- a/src/public/sw.js
+++ b/src/public/sw.js
@@ -1,7 +1,7 @@
 /* eslint-disable unicorn/no-null */
-/* global self, clients */
+/* global clients */
 
-self.addEventListener('push', (event) => {
+globalThis.addEventListener('push', (event) => {
   try {
     if (
       globalThis.Notification == null ||
@@ -31,7 +31,7 @@ self.addEventListener('push', (event) => {
   }
 })
 
-self.addEventListener('notificationclick', (event) => {
+globalThis.addEventListener('notificationclick', (event) => {
   try {
     // @ts-expect-error event.notification is not null
     event.notification.close()

--- a/src/utils/destination.ts
+++ b/src/utils/destination.ts
@@ -115,8 +115,8 @@ class WebPushDestination extends BaseDestination {
       return
     }
 
-    const rawTitle = message.split('\n')[0]
-    const rawBody = message.split('\n').slice(1).join('\n')
+    const rawTitle = message.split('\n', 1)[0]
+    const rawBody = message.slice(rawTitle.length + 1)
     const title = rawTitle
       .replaceAll('☎ ', '')
       .replaceAll('**', '')

--- a/src/web/view.ts
+++ b/src/web/view.ts
@@ -19,7 +19,7 @@ export class ViewRouter extends BaseRouter {
   ) {
     let path = request.url
     if (path.includes('?')) {
-      path = path.split('?')[0]
+      path = path.split('?', 1)[0]
     }
     if (path === '') {
       path = 'index.html'


### PR DESCRIPTION
## 概要

eslint-plugin-unicorn v65 系（@book000/eslint-config のバージョンアップに伴う）の新規 ESLint ルールへの違反を修正します。

Fixes #2355

## 変更内容

### src/public/sw.js

Service Worker において `self` を `globalThis` に置き換えました。

- **ルール**: `unicorn/prefer-global-this`
- **変更箇所**: Line 4, 34
- `self.addEventListener(...)` → `globalThis.addEventListener(...)`
- `/* global self, clients */` → `/* global clients */`（`self` は不要なため除去）

### src/utils/destination.ts

`String#split()` にリミット引数を追加しました。

- **ルール**: `unicorn/string-split-limit`
- **変更箇所**: Line 118–119
- `message.split('\n')[0]` → `message.split('\n', 1)[0]`（先頭要素のみ必要なためリミット 1）
- `message.split('\n').slice(1).join('\n')` → `message.slice(rawTitle.length + 1)`（2 回目の split を排除しリミット問題を回避）

### src/web/view.ts

`String#split()` にリミット引数を追加しました。

- **ルール**: `unicorn/string-split-limit`
- **変更箇所**: Line 22
- `path.split('?')[0]` → `path.split('?', 1)[0]`（先頭要素のみ必要なためリミット 1）

## 確認事項

- [x] `pnpm lint` が成功していること
- [x] `tsc --noEmit` が成功していること（型エラーなし）
- [x] Renovate PR (#2346) への直接コミットなし（別ブランチで対応）