### PR TITLE
fix: book000 reusable workflowのdigest指定をmasterに変更する

### DIFF
--- a/.github/workflows/add-reviewer.yml
+++ b/.github/workflows/add-reviewer.yml
@@ -12,4 +12,4 @@ on:
 jobs:
   add-reviewer:
     name: Add reviewer
-    uses: book000/templates/.github/workflows/reusable-add-reviewer.yml@a8b7f3c4f10d3da67893d91f84f8a019bf79ed4d # master
+    uses: book000/templates/.github/workflows/reusable-add-reviewer.yml@master

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -78,7 +78,7 @@ jobs:
     name: Docker CI
     needs: approval-gate
     if: always() && needs.approval-gate.result == 'success' && (github.event.action != 'closed' || github.event.pull_request.merged == true)
-    uses: book000/templates/.github/workflows/reusable-docker.yml@a8b7f3c4f10d3da67893d91f84f8a019bf79ed4d # master
+    uses: book000/templates/.github/workflows/reusable-docker.yml@master
     with:
       targets: >-
         [

--- a/.github/workflows/hadolint-ci.yml
+++ b/.github/workflows/hadolint-ci.yml
@@ -13,4 +13,4 @@ on:
 jobs:
   hadolint:
     name: hadolint
-    uses: book000/templates/.github/workflows/reusable-hadolint-ci.yml@a8b7f3c4f10d3da67893d91f84f8a019bf79ed4d # master
+    uses: book000/templates/.github/workflows/reusable-hadolint-ci.yml@master

--- a/.github/workflows/nodejs-ci-pnpm.yml
+++ b/.github/workflows/nodejs-ci-pnpm.yml
@@ -16,4 +16,4 @@ on:
 jobs:
   node-ci:
     name: Node CI
-    uses: book000/templates/.github/workflows/reusable-nodejs-ci-pnpm.yml@a8b7f3c4f10d3da67893d91f84f8a019bf79ed4d # master
+    uses: book000/templates/.github/workflows/reusable-nodejs-ci-pnpm.yml@master


### PR DESCRIPTION
## 概要

Renovate が book000/templates 参照の digest 固定を自動更新し続けていたため、
book000/book000#124 のロールアウト対応（`@master` 参照への変更）を再適用します。
`allow-unsafe-pr-checkout` は既に設定済みのため変更していません。

## 背景

book000/templates#432 の Renovate 設定バグにより、本リポジトリを含む複数リポジトリで
一度適用した `@master` 化が digest 固定へ巻き戻されていました。
book000/templates#434 で Renovate 設定は修正済みですが、既に digest 固定された参照は
そのまま更新が継続してしまうため、本 PR で改めて `@master` 参照へ戻します。

Refs: book000/book000#124
Refs: book000/templates#432
Refs: book000/templates#434