### PR TITLE
fix: eslint-plugin-unicorn v71 の新規ルール違反を修正

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "type": "git"
   },
   "scripts": {
-    "generate-schema": "typescript-json-schema --required tsconfig.json Configuration -o schema/Configuration.json",
+    "generate-schema": "typescript-json-schema --required tsconfig.json Config -o schema/Configuration.json",
     "lint:prettier": "prettier --check src",
     "lint:tsc": "tsc",
     "fix:eslint": "eslint . -c eslint.config.mjs --fix",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "fix": "run-z fix:prettier,fix:eslint"
   },
   "devDependencies": {
-    "@book000/eslint-config": "1.15.4",
+    "@book000/eslint-config": "1.15.44",
     "@book000/node-utils": "1.24.274",
     "@fastify/basic-auth": "6.2.0",
     "@fastify/cors": "11.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     devDependencies:
       '@book000/eslint-config':
-        specifier: 1.15.4
-        version: 1.15.4(eslint@10.6.0)(typescript@6.0.3)
+        specifier: 1.15.44
+        version: 1.15.44(eslint@10.6.0)(typescript@6.0.3)
       '@book000/node-utils':
         specifier: 1.24.274
         version: 1.24.274
@@ -37,7 +37,7 @@ importers:
         version: 10.6.0
       eslint-config-standard:
         specifier: 17.1.0
-        version: 17.1.0(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.61.0(eslint@10.6.0)(typescript@6.0.3))(eslint@10.6.0))(eslint-plugin-n@17.24.0(eslint@10.6.0)(typescript@6.0.3))(eslint-plugin-promise@7.3.0(eslint@10.6.0))(eslint@10.6.0)
+        version: 17.1.0(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.63.0(eslint@10.6.0)(typescript@6.0.3))(eslint@10.6.0))(eslint-plugin-n@17.24.0(eslint@10.6.0)(typescript@6.0.3))(eslint-plugin-promise@7.3.0(eslint@10.6.0))(eslint@10.6.0)
       fastify:
         specifier: 5.10.0
         version: 5.10.0
@@ -62,14 +62,10 @@ importers:
 
 packages:
 
-  '@babel/helper-validator-identifier@7.29.7':
-    resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
-    engines: {node: '>=6.9.0'}
-
-  '@book000/eslint-config@1.15.4':
-    resolution: {integrity: sha512-ZoYNeauKfLCW1EaJNd2ISRcfqIHEYWJyHrKV4vag8iOlou+eXdvZw60EWKnqvznNBpkaeLg4MmgM5m7M5dWBlQ==}
+  '@book000/eslint-config@1.15.44':
+    resolution: {integrity: sha512-N1lvgGdTMNphDTVWbtOslyGSjC75R0O5mawxdnWtrWaClrMNNLC7X2SgI5CM01HO0B3fMpVeGfDDM9220E0+bA==}
     peerDependencies:
-      eslint: 10.5.0
+      eslint: 10.6.0
 
   '@book000/node-utils@1.24.274':
     resolution: {integrity: sha512-GLt0OOcYjShe89Nfxa4H8PqKEjlK2ET3dqWxMrYd3l0UhHdlDL0ZK5vzd7RTGY22Ecz6ZUdC7DdC/ldd36s+MA==}
@@ -388,8 +384,23 @@ packages:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.1.0'
 
+  '@typescript-eslint/eslint-plugin@8.63.0':
+    resolution: {integrity: sha512-rvwSgqT+DHpWdzfSzPatRLm02a0GlESt++9iy3hLCDY4BgkaLcl8LBi9Yh7XGFBpwcBE/K3024QuXWTpbz4FfQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      '@typescript-eslint/parser': ^8.63.0
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
   '@typescript-eslint/parser@8.61.0':
     resolution: {integrity: sha512-5B7PfA2e1NQGCnDHd/0lW7W3gvp3d59Ryw54FYO8Uswxo9f6ikw3AZV+Xj/TvpImmpsiYyUqAfhC6kJID1jF6w==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/parser@8.63.0':
+    resolution: {integrity: sha512-gwh4gvvlaVDKKxyfxMG+Gnu1u9X0OQBwyGLkbwB65dIzBKnxeRiJlNFqlI3zwVhNXJIs6qV7mlFCn/BIajlVig==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
@@ -407,12 +418,22 @@ packages:
     peerDependencies:
       typescript: '>=4.8.4 <6.1.0'
 
+  '@typescript-eslint/project-service@8.63.0':
+    resolution: {integrity: sha512-e5dh0/UI0ok53AlZ5wRkXCB32z/f2jUZqPR/ygAw5WYaSw8j9EoJWlS7wQjr/dmOaqWjnPIn2m+HhVPCMWGZVQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
   '@typescript-eslint/scope-manager@8.61.0':
     resolution: {integrity: sha512-IWdXFHFSb6mlC3HPc7QsLDm5zYEbUla6trDEHf32D3/dnuUyXd87plScSNXSbm0/RxMvObpI17sv/EDTGrGZkA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@typescript-eslint/scope-manager@8.62.1':
     resolution: {integrity: sha512-r4d249KbQ1SFdpeStvob8Ih6aPPIzfqllPVOtvhve6ZcpuVcYo5/7zUWckKpHE7StASX4kTKZTLf0WQm/wPkcg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/scope-manager@8.63.0':
+    resolution: {integrity: sha512-uUyfMWCnDSN8bCpcrY8nGP2BLkQ9Xn0GsipcONcpIDWhwhO4ZSyHvyS14U3X75mzxWxL3I2UZIrenTzdzcJO8A==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@typescript-eslint/tsconfig-utils@8.61.0':
@@ -427,8 +448,21 @@ packages:
     peerDependencies:
       typescript: '>=4.8.4 <6.1.0'
 
+  '@typescript-eslint/tsconfig-utils@8.63.0':
+    resolution: {integrity: sha512-sUAbkulqBAsncKnbRP3+7CtQFRKicexnj7ZwNC6ddCR7EmrXvjvdCYMJbUIqMd6lwoEriZjwLo08aS5tSjVMHg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
   '@typescript-eslint/type-utils@8.61.0':
     resolution: {integrity: sha512-TuBiQYIkd97yBfInHCTKVYMbX4kvEmpOEuixIuzCU9p8BGT1SfyyO0d0IfDMbPIHcjn/hWnusUX5e8v5Xg+X8A==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/type-utils@8.63.0':
+    resolution: {integrity: sha512-Nzzh/OGxVCOjObjaj1CQF2RUasyYy2Jfuh+zZ3PjLzG2fYRriAiZLib9UKtO+CpQAS3YHiAS+ckZDclwqI1TPA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
@@ -442,6 +476,10 @@ packages:
     resolution: {integrity: sha512-ooCzJFaf+Hg+uG6fA3NRFGuFjlfNlDhBthbv4ZPU/0elCAFUfnyXUvf/WOpHz/jYwSmvU2GkR2LtyUfy1AxZ1Q==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@typescript-eslint/types@8.63.0':
+    resolution: {integrity: sha512-xyLtl9DUBBFrcJS4x2pIqGLH68/tC2uOa4Z7pUteW09D3bXnnXUom4dyPikzWgB7llmIc1zoeI3aoUdC4rPK/Q==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
   '@typescript-eslint/typescript-estree@8.61.0':
     resolution: {integrity: sha512-42zatd5qSvvcV1JdDBCLxYRznvP4eIHpPoZXdkPFnAmanA4FuZ5dibSnCBggY8hQnqajPpoGjXFdZ7fIJKQnlA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -450,6 +488,12 @@ packages:
 
   '@typescript-eslint/typescript-estree@8.62.1':
     resolution: {integrity: sha512-xMcW9oP9u7fAMXYs9A65CVmtLQe2r//oXINHfi8HV+oiqhih17sbLdhXr4540YWlgpDKQdY854OL5ZrdCiQsAA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/typescript-estree@8.63.0':
+    resolution: {integrity: sha512-ygBkU+B7ex5UI/gKhaqexWev79uISfIv7XQCRNYO/jmD8rGLPyWLAb3KMRT6nd8Gt9bmUBi9+iX6tBdYfOY81Q==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: '>=4.8.4 <6.1.0'
@@ -468,12 +512,23 @@ packages:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.1.0'
 
+  '@typescript-eslint/utils@8.63.0':
+    resolution: {integrity: sha512-fUKaeAvrTuQg/Tgt3nliAUSZHJM6DlCcfyEmxCvlX8kieWSStBX+5O5Fnidtc3i2JrH+9c/GL4RY2iasd/GPTA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
   '@typescript-eslint/visitor-keys@8.61.0':
     resolution: {integrity: sha512-QVLZu3ZPQEE+HICQyAMZ2yLQhxf0meY/wx6Hx14YcTNj13JB3qHlX3lJ02L3fLGHgERRH71kvYDwiXIguT3AjQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@typescript-eslint/visitor-keys@8.62.1':
     resolution: {integrity: sha512-4g3BLxfdTMy8iZG0MaBkadnlRrCJ74cQiFbyEVMrkwIoqdyaXXQM22cotDvrl4x28wgIZ9rEJRoM+mmhSJpJ1g==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/visitor-keys@8.63.0':
+    resolution: {integrity: sha512-UexrHGnGTpbuQHct2ExOc2ZcFbGUS9FOesCxxqdBGcpI1BxYu/LZ6U8Aq6/72XtF/qRBk9nhuGHFJIXXMhPMdw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   abstract-logging@2.0.1:
@@ -679,6 +734,10 @@ packages:
 
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+
+  convert-hrtime@5.0.0:
+    resolution: {integrity: sha512-lOETlkIeYSJWcbbcvjRKGxVMXJR+8+OQb/mTPbA4ObPMytYIsUbuOE0Jzy60hjARYszq1id0j8KgVhC+WGZVTg==}
+    engines: {node: '>=12'}
 
   cookie@1.1.1:
     resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
@@ -941,11 +1000,11 @@ packages:
     peerDependencies:
       eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7
 
-  eslint-plugin-unicorn@65.0.1:
-    resolution: {integrity: sha512-daCrQrgxOoOz2uMPWB3Y3vvv/5q+ncwICI8IjoebiwtW87CaY4tAN5EEiRXTYVnf7qi1v1BGBdHOSnZLV0rx6A==}
-    engines: {node: ^20.10.0 || >=21.0.0}
+  eslint-plugin-unicorn@71.1.0:
+    resolution: {integrity: sha512-dn3YmR3qLLUeYyo/os3ubZ7UHQJ1WbBAgC9cIhnLTyMj9J6kivuc2U1fCmYetLexUlTDVYtBqhjSj/VaebTe6Q==}
+    engines: {node: '>=22'}
     peerDependencies:
-      eslint: '>=9.38.0'
+      eslint: '>=10.4'
 
   eslint-scope@9.1.2:
     resolution: {integrity: sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==}
@@ -1090,6 +1149,10 @@ packages:
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
 
+  function-timeout@1.0.2:
+    resolution: {integrity: sha512-939eZS4gJ3htTHAldmyyuzlrD58P03fHG49v2JfFXbV6OhvZKRC9j2yAtdHw/zrp2zXHuv05zMIy40F0ge7spA==}
+    engines: {node: '>=18'}
+
   function.prototype.name@1.2.0:
     resolution: {integrity: sha512-jObKIik1P2QjPHP5nz5BaOtUlfgS0fWo8IUByNXkM+o+02sJOi94em77GwJKQSJ3gfPHdgzLNrHc1uokV4P/ew==}
     engines: {node: '>= 0.4'}
@@ -1138,6 +1201,10 @@ packages:
 
   globals@17.6.0:
     resolution: {integrity: sha512-sepffkT8stwnIYbsMBpoCHJuJM5l98FUF2AnE07hfvE0m/qp3R586hw4jF4uadbhvg1ooIdzuu7CsfD2jzCaNA==}
+    engines: {node: '>=18'}
+
+  globals@17.7.0:
+    resolution: {integrity: sha512-Czmyns5dUsq4seFBR/Kdydhmo8y9kC79hiSkPn0YcGtNnYWnrgt0vjrSjx9tspoDGWm2CMarffRuLjM4xUz8xg==}
     engines: {node: '>=18'}
 
   globalthis@1.0.4:
@@ -1191,6 +1258,10 @@ packages:
   iconv-lite@0.6.3:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
     engines: {node: '>=0.10.0'}
+
+  identifier-regex@1.1.0:
+    resolution: {integrity: sha512-SLX4H/vtcYlYnL7XqnuJKHU7Z8517TgsW9nmQiGOgMCjQ8V/deLYu6bEmbGoXe7WMMhc9+EUGyFFneHja8KabA==}
+    engines: {node: '>=18'}
 
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
@@ -1278,6 +1349,10 @@ packages:
   is-glob@4.0.3:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
+
+  is-identifier@1.1.0:
+    resolution: {integrity: sha512-NhOds0mDx9lJu+1lBRO0xbwFo5nobA7GCk/0e5xjr6+6XugX985+0OyGX35BNrTkPAsdLcIKg02HUQJOK8D8kw==}
+    engines: {node: '>=18'}
 
   is-map@2.0.3:
     resolution: {integrity: sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==}
@@ -1422,6 +1497,10 @@ packages:
     resolution: {integrity: sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==}
     engines: {node: 20 || >=22}
 
+  make-asynchronous@1.1.0:
+    resolution: {integrity: sha512-ayF7iT+44LXdxJLTrTd3TLQpFDDvPCBxXxbv+pMUSuHA5Q8zyAfwkRP6aHHwNVFBUFWtxAHqwNJxF8vMZLAbVg==}
+    engines: {node: '>=18'}
+
   make-error@1.3.6:
     resolution: {integrity: sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==}
 
@@ -1531,6 +1610,10 @@ packages:
     resolution: {integrity: sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==}
     engines: {node: '>= 0.4'}
 
+  p-event@6.0.1:
+    resolution: {integrity: sha512-Q6Bekk5wpzW5qIyUP4gdMEujObYstZl6DMMOSenwBvV0BlE5LkDwkjs5yHbZmdCEq2o4RJx4tE1vwxFVf2FG1w==}
+    engines: {node: '>=16.17'}
+
   p-limit@3.1.0:
     resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
     engines: {node: '>=10'}
@@ -1546,6 +1629,10 @@ packages:
   p-locate@6.0.0:
     resolution: {integrity: sha512-wPrq66Llhl7/4AGC6I+cqxT07LhXvWL08LNXz1fENOw0Ap4sRZZ/gZpTTJ5jpurzzzfS2W/Ge9BY3LgLjCShcw==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  p-timeout@6.1.4:
+    resolution: {integrity: sha512-MyIV3ZA/PmyBN/ud8vV9XzwTrNtR4jFrObymZYnZqMmW0zA8Z17vnT0rBgFE/TlohB+YCHqXMgZzb3Csp49vqg==}
+    engines: {node: '>=14.16'}
 
   parse5-htmlparser2-tree-adapter@7.1.0:
     resolution: {integrity: sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g==}
@@ -1632,6 +1719,10 @@ packages:
   quick-format-unescaped@4.0.4:
     resolution: {integrity: sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==}
 
+  quote-js-string@0.1.0:
+    resolution: {integrity: sha512-Y3NoRtprEEZQD8RfxMCfS0ZTqc4e+i18OrXEXAvpM6TfC/3y+0L5rNbZiSnbBBEkDfFzbpd8o+cE8q3/anjMGA==}
+    engines: {node: '>=22'}
+
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
 
@@ -1661,6 +1752,10 @@ packages:
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
+
+  reserved-identifiers@1.2.0:
+    resolution: {integrity: sha512-yE7KUfFvaBFzGPs5H3Ops1RevfUEsDc5Iz65rOwWg4lE8HJSYtle77uul3+573457oHvBKuHYDl/xqUkKpEEdw==}
+    engines: {node: '>=18'}
 
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
@@ -1823,6 +1918,10 @@ packages:
     resolution: {integrity: sha512-SlyRoSkdh1dYP0PzclLE7r0M9sgbFKKMFXpFRUMNuKhQSbC6VQIGzq3E0qsfvGJaUFJPGv6Ws1NZ/haTAjfbMA==}
     engines: {node: '>=12'}
 
+  super-regex@1.1.0:
+    resolution: {integrity: sha512-WHkws2ZflZe41zj6AolvvmaTrWds/VuyeYr9iPVv/oQeaIoVxMKaushfFWpOGDT+GuBrM/sVqF8KUCYQlSSTdQ==}
+    engines: {node: '>=18'}
+
   supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
@@ -1837,6 +1936,10 @@ packages:
   thread-stream@4.2.0:
     resolution: {integrity: sha512-e2zZ96wSChazBsbENf/Pcm/4swHt2cEKQ92rhUjkL9GCKiTDJIaTBenjE/m9DXi0QBmTMDkFDdOomUy20A1tDQ==}
     engines: {node: '>=20'}
+
+  time-span@5.1.0:
+    resolution: {integrity: sha512-75voc/9G4rDIJleOo4jPvN4/YC4GRZrY8yy1uU4lwrB3XEQbWve8zXoO5No4eFrGcTAMYyoY67p8jRQdtA1HbA==}
+    engines: {node: '>=12'}
 
   tinyglobby@0.2.17:
     resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
@@ -1891,6 +1994,10 @@ packages:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
 
+  type-fest@4.41.0:
+    resolution: {integrity: sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==}
+    engines: {node: '>=16'}
+
   typed-array-buffer@1.0.3:
     resolution: {integrity: sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==}
     engines: {node: '>= 0.4'}
@@ -1909,6 +2016,13 @@ packages:
 
   typescript-eslint@8.61.0:
     resolution: {integrity: sha512-8y31Rd0eGTrDKqhy6vT0HtzhN+YLjQizwX3aA3hPXP/ynSfnrBXcQY5IzsP9/DM7+klX4IUncZZjkchP0z+rUw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  typescript-eslint@8.63.0:
+    resolution: {integrity: sha512-xgwXyzG4sK9ALkBxbyGkTMMOS+imnW65iPhxCQMK83KhxyoDNW7l+IDqEf9vMdoUidHpOoS967RCq4eMiTexwQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
@@ -1967,6 +2081,9 @@ packages:
     resolution: {integrity: sha512-OpiIUe8cuGjrj3mMBFWY+e4MMIkW3SVT+7vEIjvD9kejGUypv8GPDf84JdPWskK8zMRIJ6xYGm+Kxr8YkPyA0A==}
     engines: {node: '>= 16'}
     hasBin: true
+
+  web-worker@1.5.0:
+    resolution: {integrity: sha512-RiMReJrTAiA+mBjGONMnjVDP2u3p9R1vkcGz6gDIrOMT3oGuYwX2WRMYI9ipkphSuE5XKEhydbhNEJh4NY9mlw==}
 
   whatwg-encoding@3.1.1:
     resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
@@ -2050,17 +2167,15 @@ packages:
 
 snapshots:
 
-  '@babel/helper-validator-identifier@7.29.7': {}
-
-  '@book000/eslint-config@1.15.4(eslint@10.6.0)(typescript@6.0.3)':
+  '@book000/eslint-config@1.15.44(eslint@10.6.0)(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/parser': 8.61.0(eslint@10.6.0)(typescript@6.0.3)
+      '@typescript-eslint/parser': 8.63.0(eslint@10.6.0)(typescript@6.0.3)
       eslint: 10.6.0
       eslint-config-prettier: 10.1.8(eslint@10.6.0)
-      eslint-plugin-unicorn: 65.0.1(eslint@10.6.0)
-      globals: 17.6.0
+      eslint-plugin-unicorn: 71.1.0(eslint@10.6.0)
+      globals: 17.7.0
       neostandard: 0.13.0(eslint@10.6.0)(typescript@6.0.3)
-      typescript-eslint: 8.61.0(eslint@10.6.0)(typescript@6.0.3)
+      typescript-eslint: 8.63.0(eslint@10.6.0)(typescript@6.0.3)
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -2320,6 +2435,22 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/eslint-plugin@8.63.0(@typescript-eslint/parser@8.63.0(eslint@10.6.0)(typescript@6.0.3))(eslint@10.6.0)(typescript@6.0.3)':
+    dependencies:
+      '@eslint-community/regexpp': 4.12.2
+      '@typescript-eslint/parser': 8.63.0(eslint@10.6.0)(typescript@6.0.3)
+      '@typescript-eslint/scope-manager': 8.63.0
+      '@typescript-eslint/type-utils': 8.63.0(eslint@10.6.0)(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.63.0(eslint@10.6.0)(typescript@6.0.3)
+      '@typescript-eslint/visitor-keys': 8.63.0
+      eslint: 10.6.0
+      ignore: 7.0.5
+      natural-compare: 1.4.0
+      ts-api-utils: 2.5.0(typescript@6.0.3)
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/parser@8.61.0(eslint@10.6.0)(typescript@6.0.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.61.0
@@ -2332,10 +2463,22 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/parser@8.63.0(eslint@10.6.0)(typescript@6.0.3)':
+    dependencies:
+      '@typescript-eslint/scope-manager': 8.63.0
+      '@typescript-eslint/types': 8.63.0
+      '@typescript-eslint/typescript-estree': 8.63.0(typescript@6.0.3)
+      '@typescript-eslint/visitor-keys': 8.63.0
+      debug: 4.4.3
+      eslint: 10.6.0
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/project-service@8.61.0(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.61.0(typescript@6.0.3)
-      '@typescript-eslint/types': 8.61.0
+      '@typescript-eslint/tsconfig-utils': 8.62.1(typescript@6.0.3)
+      '@typescript-eslint/types': 8.62.1
       debug: 4.4.3
       typescript: 6.0.3
     transitivePeerDependencies:
@@ -2345,6 +2488,15 @@ snapshots:
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.62.1(typescript@6.0.3)
       '@typescript-eslint/types': 8.62.1
+      debug: 4.4.3
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/project-service@8.63.0(typescript@6.0.3)':
+    dependencies:
+      '@typescript-eslint/tsconfig-utils': 8.63.0(typescript@6.0.3)
+      '@typescript-eslint/types': 8.63.0
       debug: 4.4.3
       typescript: 6.0.3
     transitivePeerDependencies:
@@ -2360,11 +2512,20 @@ snapshots:
       '@typescript-eslint/types': 8.62.1
       '@typescript-eslint/visitor-keys': 8.62.1
 
+  '@typescript-eslint/scope-manager@8.63.0':
+    dependencies:
+      '@typescript-eslint/types': 8.63.0
+      '@typescript-eslint/visitor-keys': 8.63.0
+
   '@typescript-eslint/tsconfig-utils@8.61.0(typescript@6.0.3)':
     dependencies:
       typescript: 6.0.3
 
   '@typescript-eslint/tsconfig-utils@8.62.1(typescript@6.0.3)':
+    dependencies:
+      typescript: 6.0.3
+
+  '@typescript-eslint/tsconfig-utils@8.63.0(typescript@6.0.3)':
     dependencies:
       typescript: 6.0.3
 
@@ -2380,9 +2541,23 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/type-utils@8.63.0(eslint@10.6.0)(typescript@6.0.3)':
+    dependencies:
+      '@typescript-eslint/types': 8.63.0
+      '@typescript-eslint/typescript-estree': 8.63.0(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.63.0(eslint@10.6.0)(typescript@6.0.3)
+      debug: 4.4.3
+      eslint: 10.6.0
+      ts-api-utils: 2.5.0(typescript@6.0.3)
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/types@8.61.0': {}
 
   '@typescript-eslint/types@8.62.1': {}
+
+  '@typescript-eslint/types@8.63.0': {}
 
   '@typescript-eslint/typescript-estree@8.61.0(typescript@6.0.3)':
     dependencies:
@@ -2414,6 +2589,21 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/typescript-estree@8.63.0(typescript@6.0.3)':
+    dependencies:
+      '@typescript-eslint/project-service': 8.63.0(typescript@6.0.3)
+      '@typescript-eslint/tsconfig-utils': 8.63.0(typescript@6.0.3)
+      '@typescript-eslint/types': 8.63.0
+      '@typescript-eslint/visitor-keys': 8.63.0
+      debug: 4.4.3
+      minimatch: 10.2.5
+      semver: 7.8.5
+      tinyglobby: 0.2.17
+      ts-api-utils: 2.5.0(typescript@6.0.3)
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/utils@8.61.0(eslint@10.6.0)(typescript@6.0.3)':
     dependencies:
       '@eslint-community/eslint-utils': 4.9.1(eslint@10.6.0)
@@ -2436,6 +2626,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/utils@8.63.0(eslint@10.6.0)(typescript@6.0.3)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.6.0)
+      '@typescript-eslint/scope-manager': 8.63.0
+      '@typescript-eslint/types': 8.63.0
+      '@typescript-eslint/typescript-estree': 8.63.0(typescript@6.0.3)
+      eslint: 10.6.0
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/visitor-keys@8.61.0':
     dependencies:
       '@typescript-eslint/types': 8.61.0
@@ -2444,6 +2645,11 @@ snapshots:
   '@typescript-eslint/visitor-keys@8.62.1':
     dependencies:
       '@typescript-eslint/types': 8.62.1
+      eslint-visitor-keys: 5.0.1
+
+  '@typescript-eslint/visitor-keys@8.63.0':
+    dependencies:
+      '@typescript-eslint/types': 8.63.0
       eslint-visitor-keys: 5.0.1
 
   abstract-logging@2.0.1: {}
@@ -2685,6 +2891,8 @@ snapshots:
       color-string: 2.1.4
 
   concat-map@0.0.1: {}
+
+  convert-hrtime@5.0.0: {}
 
   cookie@1.1.1: {}
 
@@ -2967,10 +3175,10 @@ snapshots:
     dependencies:
       eslint: 10.6.0
 
-  eslint-config-standard@17.1.0(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.61.0(eslint@10.6.0)(typescript@6.0.3))(eslint@10.6.0))(eslint-plugin-n@17.24.0(eslint@10.6.0)(typescript@6.0.3))(eslint-plugin-promise@7.3.0(eslint@10.6.0))(eslint@10.6.0):
+  eslint-config-standard@17.1.0(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.63.0(eslint@10.6.0)(typescript@6.0.3))(eslint@10.6.0))(eslint-plugin-n@17.24.0(eslint@10.6.0)(typescript@6.0.3))(eslint-plugin-promise@7.3.0(eslint@10.6.0))(eslint@10.6.0):
     dependencies:
       eslint: 10.6.0
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.61.0(eslint@10.6.0)(typescript@6.0.3))(eslint@10.6.0)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.63.0(eslint@10.6.0)(typescript@6.0.3))(eslint@10.6.0)
       eslint-plugin-n: 17.24.0(eslint@10.6.0)(typescript@6.0.3)
       eslint-plugin-promise: 7.3.0(eslint@10.6.0)
 
@@ -2982,11 +3190,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.14.0(@typescript-eslint/parser@8.61.0(eslint@10.6.0)(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint@10.6.0):
+  eslint-module-utils@2.14.0(@typescript-eslint/parser@8.63.0(eslint@10.6.0)(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint@10.6.0):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
-      '@typescript-eslint/parser': 8.61.0(eslint@10.6.0)(typescript@6.0.3)
+      '@typescript-eslint/parser': 8.63.0(eslint@10.6.0)(typescript@6.0.3)
       eslint: 10.6.0
       eslint-import-resolver-node: 0.3.10
     transitivePeerDependencies:
@@ -2999,7 +3207,7 @@ snapshots:
       eslint: 10.6.0
       eslint-compat-utils: 0.5.1(eslint@10.6.0)
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.61.0(eslint@10.6.0)(typescript@6.0.3))(eslint@10.6.0):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.63.0(eslint@10.6.0)(typescript@6.0.3))(eslint@10.6.0):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -3010,7 +3218,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 10.6.0
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.14.0(@typescript-eslint/parser@8.61.0(eslint@10.6.0)(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint@10.6.0)
+      eslint-module-utils: 2.14.0(@typescript-eslint/parser@8.63.0(eslint@10.6.0)(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint@10.6.0)
       hasown: 2.0.4
       is-core-module: 2.16.2
       is-glob: 4.0.3
@@ -3022,7 +3230,7 @@ snapshots:
       string.prototype.trimend: 1.0.10
       tsconfig-paths: 3.15.0
     optionalDependencies:
-      '@typescript-eslint/parser': 8.61.0(eslint@10.6.0)(typescript@6.0.3)
+      '@typescript-eslint/parser': 8.63.0(eslint@10.6.0)(typescript@6.0.3)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
@@ -3070,22 +3278,24 @@ snapshots:
       string.prototype.matchall: 4.0.12
       string.prototype.repeat: 1.0.0
 
-  eslint-plugin-unicorn@65.0.1(eslint@10.6.0):
+  eslint-plugin-unicorn@71.1.0(eslint@10.6.0):
     dependencies:
-      '@babel/helper-validator-identifier': 7.29.7
       '@eslint-community/eslint-utils': 4.9.1(eslint@10.6.0)
+      browserslist: 4.28.4
       change-case: 5.4.4
       ci-info: 4.4.0
       core-js-compat: 3.49.0
       detect-indent: 7.0.2
       eslint: 10.6.0
       find-up-simple: 1.0.1
-      globals: 17.6.0
+      globals: 17.7.0
       indent-string: 5.0.0
       is-builtin-module: 5.0.0
-      jsesc: 3.1.0
+      is-identifier: 1.1.0
       pluralize: 8.0.0
+      quote-js-string: 0.1.0
       regjsparser: 0.13.2
+      reserved-identifiers: 1.2.0
       semver: 7.8.5
       strip-indent: 4.1.1
 
@@ -3269,6 +3479,8 @@ snapshots:
 
   function-bind@1.1.2: {}
 
+  function-timeout@1.0.2: {}
+
   function.prototype.name@1.2.0:
     dependencies:
       call-bind: 1.0.9
@@ -3331,6 +3543,8 @@ snapshots:
 
   globals@17.6.0: {}
 
+  globals@17.7.0: {}
+
   globalthis@1.0.4:
     dependencies:
       define-properties: 1.2.1
@@ -3381,6 +3595,10 @@ snapshots:
   iconv-lite@0.6.3:
     dependencies:
       safer-buffer: 2.1.2
+
+  identifier-regex@1.1.0:
+    dependencies:
+      reserved-identifiers: 1.2.0
 
   ignore@5.3.2: {}
 
@@ -3467,6 +3685,11 @@ snapshots:
   is-glob@4.0.3:
     dependencies:
       is-extglob: 2.1.1
+
+  is-identifier@1.1.0:
+    dependencies:
+      identifier-regex: 1.1.0
+      super-regex: 1.1.0
 
   is-map@2.0.3: {}
 
@@ -3618,6 +3841,12 @@ snapshots:
 
   lru-cache@11.5.1: {}
 
+  make-asynchronous@1.1.0:
+    dependencies:
+      p-event: 6.0.1
+      type-fest: 4.41.0
+      web-worker: 1.5.0
+
   make-error@1.3.6: {}
 
   math-intrinsics@1.1.0: {}
@@ -3745,6 +3974,10 @@ snapshots:
       object-keys: 1.1.1
       safe-push-apply: 1.0.0
 
+  p-event@6.0.1:
+    dependencies:
+      p-timeout: 6.1.4
+
   p-limit@3.1.0:
     dependencies:
       yocto-queue: 0.1.0
@@ -3760,6 +3993,8 @@ snapshots:
   p-locate@6.0.0:
     dependencies:
       p-limit: 4.0.0
+
+  p-timeout@6.1.4: {}
 
   parse5-htmlparser2-tree-adapter@7.1.0:
     dependencies:
@@ -3837,6 +4072,8 @@ snapshots:
 
   quick-format-unescaped@4.0.4: {}
 
+  quote-js-string@0.1.0: {}
+
   react-is@16.13.1: {}
 
   readable-stream@3.6.2:
@@ -3874,6 +4111,8 @@ snapshots:
       jsesc: 3.1.0
 
   require-from-string@2.0.2: {}
+
+  reserved-identifiers@1.2.0: {}
 
   resolve-pkg-maps@1.0.0: {}
 
@@ -4083,6 +4322,12 @@ snapshots:
 
   strip-indent@4.1.1: {}
 
+  super-regex@1.1.0:
+    dependencies:
+      function-timeout: 1.0.2
+      make-asynchronous: 1.1.0
+      time-span: 5.1.0
+
   supports-preserve-symlinks-flag@1.0.0: {}
 
   tapable@2.3.3: {}
@@ -4092,6 +4337,10 @@ snapshots:
   thread-stream@4.2.0:
     dependencies:
       real-require: 1.0.0
+
+  time-span@5.1.0:
+    dependencies:
+      convert-hrtime: 5.0.0
 
   tinyglobby@0.2.17:
     dependencies:
@@ -4148,6 +4397,8 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
 
+  type-fest@4.41.0: {}
+
   typed-array-buffer@1.0.3:
     dependencies:
       call-bound: 1.0.4
@@ -4187,6 +4438,17 @@ snapshots:
       '@typescript-eslint/parser': 8.61.0(eslint@10.6.0)(typescript@6.0.3)
       '@typescript-eslint/typescript-estree': 8.61.0(typescript@6.0.3)
       '@typescript-eslint/utils': 8.61.0(eslint@10.6.0)(typescript@6.0.3)
+      eslint: 10.6.0
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  typescript-eslint@8.63.0(eslint@10.6.0)(typescript@6.0.3):
+    dependencies:
+      '@typescript-eslint/eslint-plugin': 8.63.0(@typescript-eslint/parser@8.63.0(eslint@10.6.0)(typescript@6.0.3))(eslint@10.6.0)(typescript@6.0.3)
+      '@typescript-eslint/parser': 8.63.0(eslint@10.6.0)(typescript@6.0.3)
+      '@typescript-eslint/typescript-estree': 8.63.0(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.63.0(eslint@10.6.0)(typescript@6.0.3)
       eslint: 10.6.0
       typescript: 6.0.3
     transitivePeerDependencies:
@@ -4252,6 +4514,8 @@ snapshots:
       minimist: 1.2.8
     transitivePeerDependencies:
       - supports-color
+
+  web-worker@1.5.0: {}
 
   whatwg-encoding@3.1.1:
     dependencies:

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,10 +1,5 @@
 import { Checked } from './utils/checked'
-import {
-  CallDetail,
-  Configuration,
-  IDestination,
-  loadConfig,
-} from './utils/config'
+import { CallDetail, Config, IDestination, loadConfig } from './utils/config'
 import { getDestination } from './utils/destination'
 import { Logger } from '@book000/node-utils'
 import { NVR510, SyslogCall } from './utils/nvr510'
@@ -60,7 +55,7 @@ function getCallerName(callerResult: PhoneDetailResult) {
 }
 
 function getIDestinations(
-  config: Configuration,
+  config: Config,
   detail: CallDetail
 ): IDestination[] | null {
   const destination = config.destinations.filter((d) =>
@@ -73,7 +68,7 @@ function getIDestinations(
   return destination.length > 0 ? destination : null
 }
 
-function getSelfName(config: Configuration, detail: CallDetail): string {
+function getSelfName(config: Config, detail: CallDetail): string {
   const self = config.selfs.find((d) =>
     Object.entries(d.condition).every(
       // @ts-expect-error インデックスがstringなのでエラー
@@ -124,7 +119,7 @@ function getGoogleSearchMessage(
   ].join('\n')
 }
 
-async function checker(config: Configuration) {
+async function checker(config: Config) {
   const logger = Logger.configure('checker')
   logger.info('✨ checker()')
   const isFirst = Checked.isFirst()
@@ -213,9 +208,7 @@ async function main() {
     logger.info('🚀 Start web server')
     const app = await buildWebApp(config, webPush)
     const host = process.env.API_HOST ?? '0.0.0.0'
-    const port = process.env.API_PORT
-      ? Number.parseInt(process.env.API_PORT, 10)
-      : 8000
+    const port = process.env.API_PORT ? Number(process.env.API_PORT) : 8000
     app.listen({ host, port }, (error, address) => {
       if (error) {
         logger.error('❌ Fastify.listen error', error)
@@ -229,11 +222,11 @@ async function main() {
   logger.info('🔍 Start checking')
 
   while (true) {
-    await checker(config)
-      // eslint-disable-next-line @typescript-eslint/no-empty-function
-      .then(() => {})
-      // eslint-disable-next-line @typescript-eslint/no-empty-function
-      .catch(() => {})
+    try {
+      await checker(config)
+    } catch (error) {
+      logger.error('❌ checker() failed', error as Error)
+    }
     await new Promise((resolve) => setTimeout(resolve, 1000))
   }
 }

--- a/src/public/script.js
+++ b/src/public/script.js
@@ -13,10 +13,7 @@ async function isWebPushSupported() {
   try {
     const sw = await navigator.serviceWorker.ready
     // 利用可能になったサービスワーカーがpushManagerプロパティがあればPush APIに対応しているとみなす
-    if (!('pushManager' in sw)) {
-      return false
-    }
-    return true
+    return !!('pushManager' in sw)
   } catch {
     return false
   }
@@ -71,18 +68,15 @@ async function subscribe(destinationName) {
     if (result === 'default') {
       throw new Error('Permission prompt dismissed.')
     }
-  }
-  if (globalThis.Notification.permission === 'denied') {
+  } else if (globalThis.Notification.permission === 'denied') {
     throw new Error('Permission denied.')
   }
 
-  const currentLocalSubscription = await navigator.serviceWorker.ready.then(
-    (worker) =>
-      worker.pushManager.subscribe({
-        userVisibleOnly: true,
-        applicationServerKey: validPublicKey,
-      })
-  )
+  const worker = await navigator.serviceWorker.ready
+  const currentLocalSubscription = await worker.pushManager.subscribe({
+    userVisibleOnly: true,
+    applicationServerKey: validPublicKey,
+  })
 
   const subscriptionJSON = currentLocalSubscription.toJSON()
   if (
@@ -108,10 +102,7 @@ async function subscribe(destinationName) {
         },
       }),
     })
-    if (!response.ok) {
-      return false
-    }
-    return true
+    return !!response.ok
   } catch {
     return false
   }
@@ -153,11 +144,7 @@ async function unsubscribe(destinationName) {
     throw new Error('Already unsubscribed.')
   }
 
-  if (!response.ok) {
-    return false
-  }
-
-  return true
+  return !!response.ok
 }
 
 async function main() {
@@ -186,8 +173,7 @@ async function main() {
   }
 
   forceReloadButton.addEventListener('click', () => {
-    // @ts-expect-error reload argument is not in the spec
-    globalThis.location.reload(true)
+    globalThis.location.reload()
   })
 
   const isSupported = await isWebPushSupported()
@@ -199,12 +185,11 @@ async function main() {
 
   subscribeButton.disabled = true
   unsubscribeButton.disabled = true
-  initDestinationNameSelect(destinationNameSelect).then(() => {
-    subscribeButton.disabled = false
-    unsubscribeButton.disabled = false
+  await initDestinationNameSelect(destinationNameSelect)
+  subscribeButton.disabled = false
+  unsubscribeButton.disabled = false
 
-    modal.classList.remove('is-active')
-  })
+  modal.classList.remove('is-active')
 
   subscribeButton.addEventListener('click', async () => {
     try {

--- a/src/utils/checked.ts
+++ b/src/utils/checked.ts
@@ -12,7 +12,7 @@ export class Checked {
   }
 
   public static isChecked(date: string, time: string): boolean {
-    const checked = Checked.load()
+    const checked = this.load()
     if (!checked) {
       return false
     }
@@ -23,12 +23,12 @@ export class Checked {
 
   public static check(date: string, time: string): void {
     const dateObject = this.convertDate(date, time)
-    const previousChecked = Checked.load()
+    const previousChecked = this.load()
     if (previousChecked && new Date(previousChecked.datetime) >= dateObject) {
       return
     }
 
-    Checked.save({
+    this.save({
       datetime: dateObject.toISOString(),
     })
   }

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -70,7 +70,7 @@ interface Self {
   condition: Conditions
 }
 
-export interface Configuration {
+export interface Config {
   destinations: IDestination[]
   selfs: Self[]
   router: {
@@ -172,11 +172,11 @@ function checkConfig(config: any): Record<string, boolean> {
   return results
 }
 
-const isConfig = (config: any): config is Configuration => {
+const isConfig = (config: any): config is Config => {
   return Object.values(checkConfig(config)).every(Boolean)
 }
 
-export function loadConfig(): Configuration {
+export function loadConfig(): Config {
   if (!fs.existsSync(PATH.CONFIG_FILE)) {
     throw new Error('Config file not found')
   }

--- a/src/utils/destination.ts
+++ b/src/utils/destination.ts
@@ -27,13 +27,13 @@ class DiscordWebhookDestination extends BaseDestination {
   }
 
   public async send(message: string): Promise<void> {
-    const res = await fetchWithKeepAlive(this.url, {
+    const response = await fetchWithKeepAlive(this.url, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ content: message }),
     })
-    if (!res.ok && res.status !== 204) {
-      throw new Error(`Discord webhook failed (${res.status})`)
+    if (!response.ok && response.status !== 204) {
+      throw new Error(`Discord webhook failed (${response.status})`)
     }
   }
 }
@@ -47,7 +47,7 @@ class DiscordBotDestination extends BaseDestination {
   }
 
   public async send(message: string): Promise<void> {
-    const res = await fetchWithKeepAlive(
+    const response = await fetchWithKeepAlive(
       `https://discord.com/api/channels/${this.channelId}/messages`,
       {
         method: 'POST',
@@ -58,8 +58,8 @@ class DiscordBotDestination extends BaseDestination {
         body: JSON.stringify({ content: message }),
       }
     )
-    if (!res.ok && res.status !== 204) {
-      throw new Error(`Discord bot message failed (${res.status})`)
+    if (!response.ok && response.status !== 204) {
+      throw new Error(`Discord bot message failed (${response.status})`)
     }
   }
 }
@@ -70,13 +70,13 @@ class SlackDestination extends BaseDestination {
   }
 
   public async send(message: string): Promise<void> {
-    const res = await fetchWithKeepAlive(this.url, {
+    const response = await fetchWithKeepAlive(this.url, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ text: message }),
     })
-    if (!res.ok) {
-      throw new Error(`Slack webhook failed (${res.status})`)
+    if (!response.ok) {
+      throw new Error(`Slack webhook failed (${response.status})`)
     }
   }
 }
@@ -89,7 +89,7 @@ class LINENotifyDestination extends BaseDestination {
   public async send(message: string): Promise<void> {
     const parameters = new URLSearchParams()
     parameters.append('message', message)
-    const res = await fetchWithKeepAlive(
+    const response = await fetchWithKeepAlive(
       'https://notify-api.line.me/api/notify',
       {
         method: 'POST',
@@ -99,8 +99,8 @@ class LINENotifyDestination extends BaseDestination {
         body: parameters,
       }
     )
-    if (!res.ok) {
-      throw new Error(`LINE Notify failed (${res.status})`)
+    if (!response.ok) {
+      throw new Error(`LINE Notify failed (${response.status})`)
     }
   }
 }

--- a/src/utils/nvr510.ts
+++ b/src/utils/nvr510.ts
@@ -51,7 +51,7 @@ export class NVR510 {
 
   public async getDashboardSyslog(): Promise<SyslogItem[]> {
     // http://192.168.0.1/dashboard/syslog_data.csv?num=100
-    const res = await fetch(
+    const response = await fetch(
       `http://${this.ip}/dashboard/syslog_data.csv?num=100`,
       {
         headers: {
@@ -62,10 +62,10 @@ export class NVR510 {
         signal: AbortSignal.timeout(10_000),
       }
     )
-    if (!res.ok) {
-      throw new Error(`Failed to get syslog: ${res.status}`)
+    if (!response.ok) {
+      throw new Error(`Failed to get syslog: ${response.status}`)
     }
-    const text = await res.text()
+    const text = await response.text()
     const data = text
       .replaceAll('&nbsp;', ' ')
       .replaceAll('<br>', '')

--- a/src/utils/search-number.ts
+++ b/src/utils/search-number.ts
@@ -1,7 +1,7 @@
 // axios 削除
 
 import { load } from 'cheerio'
-import { Configuration, PATH } from './config'
+import { Config, PATH } from './config'
 import fs from 'node:fs'
 import { Logger } from '@book000/node-utils'
 
@@ -96,14 +96,14 @@ class TelNavi extends BaseSearchNumber {
   }
 
   public async search(number: string): Promise<PhoneDetailResult> {
-    const res = await fetch(`https://telnavi.jp/phone/${number}`, {
+    const response = await fetch(`https://telnavi.jp/phone/${number}`, {
       signal: AbortSignal.timeout(10_000),
       headers: { 'User-Agent': 'Mozilla/5.0 (compatible; telcheck)' },
     })
-    if (!res.ok) {
-      throw new Error(`Failed to get telnavi: ${res.status}`)
+    if (!response.ok) {
+      throw new Error(`Failed to get telnavi: ${response.status}`)
     }
-    const html = await res.text()
+    const html = await response.text()
     const $ = load(html)
     const title = $('title').text()
     const match = this.titleRegex.exec(title)
@@ -119,9 +119,9 @@ class TelNavi extends BaseSearchNumber {
 }
 
 class GoogleSearch extends BaseSearchNumber {
-  private readonly config: Configuration
+  private readonly config: Config
 
-  constructor(config: Configuration) {
+  constructor(config: Config) {
     super('Google検索')
 
     this.config = config
@@ -137,13 +137,13 @@ class GoogleSearch extends BaseSearchNumber {
     const searchCx = this.config.google_search.cx
 
     const url = `https://www.googleapis.com/customsearch/v1?key=${searchKey}&cx=${searchCx}&lr=lang_ja&q="${number}"`
-    const res = await fetch(url, {
+    const response = await fetch(url, {
       signal: AbortSignal.timeout(10_000),
     })
-    if (!res.ok) {
-      throw new Error(`Failed to get google search: ${res.status}`)
+    if (!response.ok) {
+      throw new Error(`Failed to get google search: ${response.status}`)
     }
-    const data: GoogleCustomSearchResponse = await res.json()
+    const data: GoogleCustomSearchResponse = await response.json()
     if (!data.items) {
       return null
     }
@@ -162,7 +162,7 @@ class GoogleSearch extends BaseSearchNumber {
 }
 
 export async function searchNumber(
-  config: Configuration,
+  config: Config,
   number: string
 ): Promise<PhoneDetailResult> {
   const logger = Logger.configure('GoogleSearch::searchNumber')
@@ -173,10 +173,13 @@ export async function searchNumber(
     new GoogleSearch(config),
   ]
   for (const searcher of searchers) {
-    const result = await searcher.search(number).catch((error: unknown) => {
+    let result: PhoneDetailResult | null
+    try {
+      result = await searcher.search(number)
+    } catch (error) {
       logger.error('Failed to search number', error as Error)
-      return null
-    })
+      result = null
+    }
     if (result) {
       return result
     }

--- a/src/utils/web-push.ts
+++ b/src/utils/web-push.ts
@@ -47,8 +47,8 @@ export class WebPush {
   }
 
   public static getInstance(): WebPush {
-    WebPush.instance ??= new WebPush()
-    return WebPush.instance
+    this.instance ??= new WebPush()
+    return this.instance
   }
 
   public getBase64PublicKey(): string {
@@ -108,23 +108,19 @@ export class WebPush {
     payload: string
   ): Promise<number> {
     const logger = Logger.configure('WebPush.sendNotification')
-    const response = await webpush
-      .sendNotification(subscription, payload, {
+    try {
+      const response = await webpush.sendNotification(subscription, payload, {
         vapidDetails: {
           subject: `mailto:${process.env.WEB_PUSH_EMAIL}`,
           publicKey: this.vapidPublicKey,
           privateKey: this.vapidPrivateKey,
         },
       })
-      .catch((error: unknown) => {
-        logger.error('Error sending notification', error as Error)
-      })
-
-    if (!response) {
+      return response.statusCode
+    } catch (error) {
+      logger.error('Error sending notification', error as Error)
       return 500
     }
-
-    return response.statusCode
   }
 
   public async sendNotifications(

--- a/src/web/api.ts
+++ b/src/web/api.ts
@@ -108,7 +108,7 @@ export class ApiRouter extends BaseRouter {
     reply: FastifyReply
   ) {
     const subscription = request.body
-    const result = this.webPush.removeSubscription(subscription)
-    await reply.code(result ? 200 : 404).send()
+    const isRemoved = this.webPush.removeSubscription(subscription)
+    await reply.code(isRemoved ? 200 : 404).send()
   }
 }

--- a/src/web/base-router.ts
+++ b/src/web/base-router.ts
@@ -1,4 +1,4 @@
-import { Configuration } from '@/utils/config'
+import { Config } from '@/utils/config'
 import { WebPush } from '@/utils/web-push'
 import { FastifyInstance } from 'fastify'
 
@@ -7,13 +7,13 @@ import { FastifyInstance } from 'fastify'
  */
 export abstract class BaseRouter {
   protected fastify: FastifyInstance
-  protected config: Configuration
+  protected config: Config
   protected webPush: WebPush
   protected version: string
 
   constructor(
     fastify: FastifyInstance,
-    config: Configuration,
+    config: Config,
     webPush: WebPush,
     version: string
   ) {

--- a/src/web/index.ts
+++ b/src/web/index.ts
@@ -2,14 +2,14 @@ import fastify from 'fastify'
 import cors from '@fastify/cors'
 import { ApiRouter } from './api'
 import { BaseRouter } from './base-router'
-import { Configuration } from '@/utils/config'
+import { Config } from '@/utils/config'
 import { WebPush } from '@/utils/web-push'
 import { Logger } from '@book000/node-utils'
 import { ViewRouter } from './view'
 import fastifyBasicAuth from '@fastify/basic-auth'
 import fs from 'node:fs'
 
-export async function buildWebApp(config: Configuration, webPush: WebPush) {
+export async function buildWebApp(config: Config, webPush: WebPush) {
   const logger = Logger.configure('buildWebApp')
 
   const app = fastify()

--- a/src/web/view.ts
+++ b/src/web/view.ts
@@ -54,7 +54,7 @@ export class ViewRouter extends BaseRouter {
         fs
           .readFileSync(`./public/${path}`)
           .toString()
-          .replaceAll('{{VERSION}}', this.version)
+          .replaceAll('{{VERSION}}', () => this.version)
       )
       return
     }


### PR DESCRIPTION
## 概要

renovate PR #2377 (`@book000/eslint-config` 1.15.4 -> 1.15.44) が `eslint-plugin-unicorn` の新しいバージョンを取り込み、既存コードに対して 28 件の lint エラーが新たに検出されるようになった。本 PR はそれらを機械的に修正する。

## 修正内容

- `unicorn/name-replacements`: `Configuration` -> `Config`、`res` -> `response` にリネーム
- `unicorn/prefer-await`: `.then()`/`.catch()` のチェーンを `try`/`await` に置き換え
- `unicorn/class-reference-in-static-methods`: static メソッド内のクラス名参照を `this` に置き換え
- `unicorn/prefer-boolean-return`, `prefer-else-if`, `prefer-number-coercion`, `no-invalid-argument-count`, `no-unsafe-string-replacement`, `consistent-boolean-name` を修正
- `generate-schema` スクリプトが参照する型名を `Configuration` -> `Config` に更新（出力される `schema/Configuration.json` の内容に変更なしを確認済み）

挙動を変えない機械的な修正であり、`pnpm run lint`（eslint / tsc / prettier）はすべて通過する。

renovate PR #2377 のマージ前提となる。