### PR TITLE
fix(lint): unicorn/prefer-split-limit 違反を修正

### DIFF
--- a/src/utils/search-number.ts
+++ b/src/utils/search-number.ts
@@ -74,7 +74,7 @@ class Phones extends BaseSearchNumber {
       .toString()
       .replaceAll('\r', '')
     const phones = tsv.split('\n').map((line) => {
-      const [name, number] = line.split('\t')
+      const [name, number] = line.split('\t', 2)
       return { name, number }
     })
     const result = phones.find((phone) => phone.number === number)


### PR DESCRIPTION
## 概要

`@book000/eslint-config` の更新（#2463）で有効化された `unicorn/prefer-split-limit` ルールが、既存コードの `src/utils/search-number.ts` を指摘していたため、明示的な limit を指定して解消した。

## 変更内容

- `line.split('\t')` → `line.split('\t', 2)`
  - 分割結果を `name`/`number` の 2 変数へ destructuring している箇所であり、limit を指定しても挙動は変わらない。

## 動作確認

- ローカルで `@book000/eslint-config` を 1.16.14（#2463 が提案しているバージョン）に一時的に上げた状態で `pnpm run lint`（prettier / eslint / tsc）が全て pass することを確認済み。
- 現行の 1.16.8 でも `pnpm run lint` が pass することを確認済み（デグレなし）。

## 関連

- #2463（`@book000/eslint-config` の Renovate PR）のこの lint 失敗を解消するための修正。