### PR TITLE
fix(search-number,web-push): 想定内の HTTP エラーを warn に留めて購読失効時に自動削除する

### DIFF
--- a/src/utils/search-number.ts
+++ b/src/utils/search-number.ts
@@ -33,6 +33,28 @@ export interface GoogleSearchResult {
 
 export type PhoneDetailResult = PhoneDetail | GoogleSearchResult | null
 
+/**
+ * 検索先サービスから返された HTTP エラーレスポンスを表すエラー
+ *
+ * アクセス制限による想定内の失敗かどうかは検索先サービスごとに意味が異なる
+ * (例: TelNavi の 403 は bot ブロック、Google Custom Search の 403 は
+ * キー設定不備やクォータ超過の可能性がある)ため、判定は throw 側で行い、
+ * 結果を `expected` に保持する。
+ * @param serviceLabel エラーメッセージに表示するサービス名
+ * @param status HTTP ステータスコード
+ * @param expected 呼び出し元でフォールバックのみで済む想定内の失敗かどうか
+ */
+class SearchNumberHttpError extends Error {
+  constructor(
+    serviceLabel: string,
+    public readonly status: number,
+    public readonly expected: boolean
+  ) {
+    super(`Failed to get ${serviceLabel}: ${status}`)
+    this.name = 'SearchNumberHttpError'
+  }
+}
+
 class BaseSearchNumber {
   public readonly serviceName: string
   constructor(serviceName: string) {
@@ -101,7 +123,13 @@ class TelNavi extends BaseSearchNumber {
       headers: { 'User-Agent': 'Mozilla/5.0 (compatible; telcheck)' },
     })
     if (!res.ok) {
-      throw new Error(`Failed to get telnavi: ${res.status}`)
+      // telnavi.jp は bot ブロックとして 403・429 を返すことがあり、
+      // 次の検索先へフォールバックするだけで済む想定内の失敗として扱う
+      throw new SearchNumberHttpError(
+        'telnavi',
+        res.status,
+        res.status === 403 || res.status === 429
+      )
     }
     const html = await res.text()
     const $ = load(html)
@@ -141,7 +169,13 @@ class GoogleSearch extends BaseSearchNumber {
       signal: AbortSignal.timeout(10_000),
     })
     if (!res.ok) {
-      throw new Error(`Failed to get google search: ${res.status}`)
+      // 403 はキー設定不備やクォータ超過など人による対応が必要な失敗の
+      // 可能性があるため想定内には含めず、429（レート制限）のみ想定内とする
+      throw new SearchNumberHttpError(
+        'google search',
+        res.status,
+        res.status === 429
+      )
     }
     const data: GoogleCustomSearchResponse = await res.json()
     if (!data.items) {
@@ -174,6 +208,12 @@ export async function searchNumber(
   ]
   for (const searcher of searchers) {
     const result = await searcher.search(number).catch((error: unknown) => {
+      // 各検索先で想定内と判定されたアクセス制限は、次の検索先へ
+      // フォールバックするだけで済むため warn に留める
+      if (error instanceof SearchNumberHttpError && error.expected) {
+        logger.warn(`Failed to search number: ${error.message}`)
+        return null
+      }
       logger.error('Failed to search number', error as Error)
       return null
     })

--- a/src/utils/web-push.ts
+++ b/src/utils/web-push.ts
@@ -1,6 +1,6 @@
 import { Logger } from '@book000/node-utils'
 import fs from 'node:fs'
-import webpush from 'web-push'
+import webpush, { WebPushError } from 'web-push'
 
 interface IWebPushKey {
   vapid: {
@@ -76,7 +76,9 @@ export class WebPush {
   public removeSubscription(subscription: Subscription): boolean {
     const subscriptions = this.getSubscriptions()
     const index = subscriptions.findIndex(
-      (s) => s.endpoint === subscription.endpoint
+      (s) =>
+        s.destinationName === subscription.destinationName &&
+        s.endpoint === subscription.endpoint
     )
     if (index === -1) {
       return false
@@ -84,6 +86,22 @@ export class WebPush {
     subscriptions.splice(index, 1)
     this.saveSubscriptions(subscriptions)
     return true
+  }
+
+  /**
+   * 指定した endpoint を持つ購読情報をすべて削除する
+   *
+   * 同一 endpoint が複数の destinationName で購読されている場合があるため、
+   * 購読が失効した際は destinationName を問わず一括で除去する。
+   * @param endpoint 削除対象の購読 endpoint
+   */
+  private removeSubscriptionsByEndpoint(endpoint: string): void {
+    const subscriptions = this.getSubscriptions()
+    const remaining = subscriptions.filter((s) => s.endpoint !== endpoint)
+    if (remaining.length === subscriptions.length) {
+      return
+    }
+    this.saveSubscriptions(remaining)
   }
 
   public getSubscriptions(): Subscription[] {
@@ -108,7 +126,7 @@ export class WebPush {
     payload: string
   ): Promise<number> {
     const logger = Logger.configure('WebPush.sendNotification')
-    const response = await webpush
+    const statusCode = await webpush
       .sendNotification(subscription, payload, {
         vapidDetails: {
           subject: `mailto:${process.env.WEB_PUSH_EMAIL}`,
@@ -116,15 +134,25 @@ export class WebPush {
           privateKey: this.vapidPrivateKey,
         },
       })
+      .then((result) => result.statusCode)
       .catch((error: unknown) => {
+        // 404・410 は購読が失効していることを示す想定内のレスポンスのため、
+        // エラー扱いにせず購読情報を削除して以後の送信対象から除外する
+        if (
+          error instanceof WebPushError &&
+          (error.statusCode === 404 || error.statusCode === 410)
+        ) {
+          logger.warn(
+            `Subscription is no longer valid, removing: ${new URL(subscription.endpoint).origin} (${subscription.destinationName})`
+          )
+          this.removeSubscriptionsByEndpoint(subscription.endpoint)
+          return error.statusCode
+        }
         logger.error('Error sending notification', error as Error)
+        return undefined
       })
 
-    if (!response) {
-      return 500
-    }
-
-    return response.statusCode
+    return statusCode ?? 500
   }
 
   public async sendNotifications(
@@ -167,11 +195,13 @@ export class WebPush {
         results.filter((r) => r === 201).length
       } subscriptions!`
     )
-    if (results.some((r) => r !== 201)) {
+    // 404・410 は失効購読として sendNotification 側で既に処理済みのため、失敗数には含めない
+    const failureCount = results.filter(
+      (r) => r !== 201 && r !== 404 && r !== 410
+    ).length
+    if (failureCount > 0) {
       logger.warn(
-        `Failed to send notification to ${
-          results.filter((r) => r !== 201).length
-        } subscriptions.`
+        `Failed to send notification to ${failureCount} subscriptions.`
       )
     }
   }


### PR DESCRIPTION
## 概要

GlitchTip issue #6 (`telnavi.jp` 検索の 403 エラー) と issue #7 (Web Push 送信の `WebPushError`) への対応。

## 変更内容

### 電話番号検索(`src/utils/search-number.ts`)

- TelNavi 検索で 403・429(アクセス制限)を受けた場合、次の検索先へフォールバックするだけで済む想定内の失敗として warn ログに留める。
- Google Custom Search の 403 はキー設定不備やクォータ超過を示す可能性があるため想定内には含めず、429(レート制限)のみを想定内として扱う。
- 各検索先が自身にとって「想定内」なステータスコードを `SearchNumberHttpError.expected` として判定する形に変更し、判定ロジックを検索先ごとに分離した。

### Web Push 通知(`src/utils/web-push.ts`)

- 送信時に 404・410(購読失効)を受けた場合、エラーとして記録せず失効した購読情報を自動的に削除する。
- 同一 endpoint が複数の送り先(destination)で購読されている場合も一括で削除するよう `removeSubscriptionsByEndpoint` を追加し、既存の `removeSubscription`(明示的な購読解除用)は `destinationName` + `endpoint` の複合キーで一致させるよう修正(`addSubscription` と対称に)。
- 404・410 を検知した際の戻り値を実際のステータスコードにし、`sendNotifications` の失敗件数集計からも除外(「エラーではない」という扱いを一貫させる)。
- 購読失効ログには endpoint 全体ではなく origin のみを出力し、GlitchTip へ機密性の高い識別子を送信しないようにした。

## 動作確認

- `pnpm lint`(ESLint + tsc)が問題なく通ることを確認。
- ローカル diff モードで `/deep-review` を実行し、指摘事項(スコア 50 以上)をすべて本 PR に反映済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J3dnbdaiA1QnWAtUgH4PsA
