### PR TITLE
chore: .worktreeinclude を追加してローカル設定ファイルを worktree 間で共有する

### DIFF
--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -1,0 +1,5 @@
+data/config.json
+data/web-push-key.json
+data/web-push-subscriptions.json
+data/phones.tsv
+data/checked.json


### PR DESCRIPTION
## 概要

`.worktreeinclude` を新規作成し、以下のパターンを追加しました。

```
data/config.json
data/web-push-key.json
data/web-push-subscriptions.json
data/phones.tsv
data/checked.json
```

## 根拠

- `src/utils/config.ts` の `loadConfig()` が `data/config.json`（`CONFIG_PATH` 環境変数で変更可能）を読み込み、ルーターのパスワードや Google Search の API キー、通知先の webhook URL / token などの機微情報を保持している。
- `Dockerfile` は `CONFIG_PATH` / `CHECKED_PATH` / `PHONES_PATH` / `WEB_PUSH_KEY_PATH` / `WEB_PUSH_SUBSCRIPTIONS_PATH` を `/data` 配下に設定し、`VOLUME ["/data"]` を宣言している。
- `compose.yaml` はホストの `./data` をコンテナの `/data` にバインドマウントしている。
- README.md の Configuration セクションで `data/config.json` の利用方法が説明されている。
- `CLAUDE.md` にも「設定ファイルは `data/config.json` が唯一のソース」「API キー・認証情報・VAPID キー・電話番号などの個人情報を Git にコミットしない」との記載がある。
- これらのファイルは `git ls-files` に含まれておらず、`.gitignore` にも明示的なエントリはない（= 新規 clone 時点では存在しない）。テンプレート（`.env.example` 等）も存在しないため、新しい git worktree では手動で再作成しない限りアプリを起動できない。

このため、`.worktreeinclude` により worktree 間でこれらのローカル専用ファイルを共有できるようにします。

関連 issue: https://github.com/book000/book000/issues/132
